### PR TITLE
Remove jquery from filter js

### DIFF
--- a/src/modules/roles-graphql.module/module.html
+++ b/src/modules/roles-graphql.module/module.html
@@ -65,20 +65,24 @@
         var params = url.searchParams;
 
         // Set it as the dropdown value
-        jQuery("#location").val(params.get("location"));
-        jQuery("#department").val(params.get("department"));
+        if (params.get('location')) {
+            document.querySelector("#location").value = params.get("location");
+        }
+        if (params.get('department')) {
+            document.querySelector("#department").value = params.get("department");
+        }
 
-        jQuery("#location").change(function() { 
+        document.querySelector("#location").addEventListener('change', function() { 
             changeFilter("location", "#location");
         });
 
-        jQuery("#department").change(function() {
+        document.querySelector("#department").addEventListener('change', function() {
             changeFilter("department", "#department");
         });
 
         function changeFilter(filterName, divName) {
             let urlParams = new URLSearchParams(document.location.search.substr(1));
-            setQueryParam(filterName, jQuery(divName).val(), urlParams);
+            setQueryParam(filterName, document.querySelector(divName).value, urlParams);
             setQueryParam("offset", 0, urlParams);
             window.location.search = urlParams.toString();
         }


### PR DESCRIPTION
Removes the dependency on jQuery, which not all customers will have enabled or as part of their site. 

My JS is a little rusty, but this seems to work in my account https://cobject.thefriendlydeveloper.com/listlist?offset=0&department=Engineering

cc @Stefanie899 @gchomatas 