### PR TITLE
Show company name when filtering by company

### DIFF
--- a/src/modules/roles-graphql.module/module.html
+++ b/src/modules/roles-graphql.module/module.html
@@ -74,6 +74,7 @@
         {% else %}
             {% set company = role.associations.company_collection__role_to_company.items|first %}
         {% endif %}
+        
         {% set roleDetailLink = "{{ request.path }}/role?role_identifier={{role.role_identifier}}&title={{role.title}}&job_title={{role.title}}" %}
         <div class="role-card" onclick="window.location='{{ roleDetailLink }}'">
             <h1>{{ role.title }}</h1>


### PR DESCRIPTION
Role listing module was relying on the role containing the associated company. When filtering by company, we don't want to include that association since we already have the company and are getting the associated roles. This change retrieves the company at the root of the data query when we're filtering by company.

Closes https://github.com/HubSpot/sample-graphql-theme/issues/21