### PR TITLE
Fixing issue in deploy file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - main
+    - master
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Making minor fix in deploy file. I noticed workflow wasn't working for deploy action but realized it is because boilerplate is using `main` as the main branch vs. `master`. It should be fine to use `master` for now but we should consider swapping over to `main` before the launch of this to stay consistent and to make sure we are using inclusive language (more details from GitHub announcement of this: https://github.com/github/renaming). 

