### PR TITLE
Fix association name to resolve issue with query

### DIFF
--- a/src/data-queries/applications.graphql
+++ b/src/data-queries/applications.graphql
@@ -10,14 +10,14 @@ query application_listings($contact_id: String!) {
       associations {
         p_job_application_collection__job_application_to_contact {
           items {
+            _metadata {
+              id
+            }
             job_title
             application_status
             associations {
               p_role_collection__role_to_job_application {
                 items {
-                  _metadata {
-                    id
-                  }
                   department
                   location
                   associations {


### PR DESCRIPTION
I noticed there was an issue when reuploading the data query for `applications`. I was able to resolve this by changing `p_role_collection__job_application_to_role` to `p_role_collection__role_to_job_application` based on what I could see in graphiql. Let me know if I might be missing anything here!

<img width="756" alt="FixQuery" src="https://user-images.githubusercontent.com/22665237/138768825-e7c593b9-18af-4818-aa94-a425fb741db5.png">


