### PR TITLE
Update cms deploy action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.3
       - name: HubSpot Deploy Action
-        uses: HubSpot/hubspot-cms-deploy-action@v1.3
+        uses: HubSpot/hubspot-cms-deploy-action@v1.4
         with:
           src_dir: src
           dest_dir: recruiting-agency-graphql-theme


### PR DESCRIPTION
Updating to the most recent version of the CMS deploy action (1.3 > 1.4) https://github.com/marketplace/actions/hubspot-cms-deploy

CC: @williamspiro 