### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Now that the custom objects are created, you can upload the theme to HubSpot by 
 
 In order to prepare for creating our pages to display roles and allow prospective applicants to apply to a given role, we’ll need to create a form that we can use on our pages. When an applicant submits this form, we want to create a contact record (if the user doesn’t already exist as a contact), and an associated Job Application object that contains their resume and cover letter.
 
-To create the form, open up HubSpot and navigate to Marketing > Lead Capture > Form. Click Create a Free Form, and select Embedded form as the type. Stick to the default Blank template and click Start to begin creating our form. By default, an Email field is already added for us, in addition to that we’ll want to drag over the First name and Last name properties to the form, as well as the Phone number property.
+To create the form, open up HubSpot and navigate to Marketing > Lead Capture > Form. Click Create a Free Form and select Embedded form as the type. Use the default Blank template and click Start to begin creating our form. By default, an Email field is already added for us, in addition to that we’ll want to drag over the First name and Last name properties to the form, as well as the Phone number property.
 
 Now, add the following fields for Job Application to our form: Salary Requirement, Resume, Cover Letter, Job title. Then add Title (under Role) and Role Identifier. For Job title, edit the field and turn off “Make this field required” and then turn on “Make this field hidden”. For this field, we’re going to automatically populate it when the applicant views a role, since it’s required to create a Job Application record, and we don’t want our applicants to have to manually fill in the field. Similarly, for Role Identifier and Title you’ll also want to make the field hidden, as it will be auto populated.
 
@@ -64,7 +64,7 @@ For the action, we want to set a property value for the object. The property we�
 
 ## Step 3: Create Role Listing and Detail Pages
 
-Now that the boilerplate objects, forms, and workflow are created, we can move on to creating the functional parts of the site where users can view roles, and submit applications for those roles. There are a number of different ways one could accomplish this.
+Now that the objects, forms, and workflow are created, we can move on to creating the functional parts of the site where users can view roles, and submit applications for those roles. There are a number of different ways one could accomplish this.
 
 The queries that will be used for our pages can be found in the “data-queries” folder of our theme. These GraphQL queries can be modified to include only the properties required for the page or modules they’re used in.
 
@@ -80,13 +80,13 @@ Finally, give the page a title and publish it.
 
 ## Step 4: Create Applications Page
 
-The final step of the process is to create a page where applicants can log in and see any pending applications they have submitted, as well as the status of those applications. In order to set this up, we’re going to utilize the Memberships feature. For more detailed information about this feature, you can go here: https://developers.hubspot.com/docs/cms/data/memberships
+The final step of the process is to create a page where applicants can log in and see any pending applications they have submitted, as well as the status of those applications. In order to set this up, we’re going to utilize the Memberships feature. For more detailed information about this feature, you can go [here](https://developers.hubspot.com/docs/cms/data/memberships).
 
-To do this, we’ll have to do to allow us to set up pages that require registration, so we need to create a Membership list. To do this, navigate to Contacts > Lists and click Create List. This list will be Contact-based, and Active. For the Filter type, select Job Application properties, select Object ID, and is known. What this means, is a Contact will automatically be added to this list when an associated Job Application has been created.
+To do this, we’ll have to set up pages that require registration, so we need to create a Membership list. To do this, navigate to Contacts > Lists and click Create List. This list will be Contact-based, and Active. For the Filter type, select Job Application properties, select Object ID, and is known. What this means, is a Contact will automatically be added to this list when an associated Job Application has been created.
 
-Now we can create the pages in our CMS. Similarly to our other pages, create a new page with the Application Listing GraphQL template. Drag in the Existing Application Listing module, and then go to the Settings for this page. Expand the Advanced options section, and select “Private - Registration required” in the “Control audience access for this page” section. This will require you to select a list to use for sending registration emails. Next, give this page a title and publish the page.
+Now we can create the pages in our CMS. Similarly to our other pages, create a new page with the Application Listing template. Go to the Settings for this page, expand the Advanced options section, and select “Private - Registration required” in the “Control audience access for this page” section. This will require you to select a list to use for sending registration emails. Next, give this page a title and publish the page.
 
-Next, create the Application Details page. Follow the same steps as above, except the template this time will be Application GraphQL and the module you’ll drag in this time is the Application Details module. Before publishing this page, ensure the Content slug is “application-details”, as that slug is hard-coded in the Existing Application Listing module.
+Next, create the Application Details page. Follow the same steps as above, except the template this time will be Application Details. Before publishing this page, ensure the Content slug is “application-details”, as that slug is hard-coded in the Application Listing module.
 
 ## Step 5: Wrapping Up
 


### PR DESCRIPTION
Updating readme: 
- Removing references to Growth theme
- Removing some steps that are no longer needed (e.g. application listing and detail modules are added to their respective templates so they no longer need to be dragged onto page)
- Cleaning up a couple things I saw when first going through

CC: @williamspiro wouldn't be a bad idea to try to get Joe's eyes on this from KB team and just have him make edits to the actual writing. I know there is this doc floating around too (https://developers.hubspot.com/docs/cms/guides/build-a-recruiting-agency-using-graphql) which looks pretty similar to the instructions in the readme so if they are the same maybe it is best if that either lives in the Readme or KB and we remove the other so there isn't duplicate content to maintain where one could get out of date. 