### PR TITLE
Fix card alignment

### DIFF
--- a/src/css/elements/_cards.css
+++ b/src/css/elements/_cards.css
@@ -11,6 +11,33 @@
   }
 }
 
+/* Blog listing - card */
+
+@media (max-width: 767px) {
+  .card-listing--2-col .card {
+    width: calc(50% - 0.7rem);
+  }
+
+  .card-listing--3-col .card {
+    width: calc(33.3% - 0.7rem);
+  }
+
+  .card-listing--4-col .card {
+    width: calc(25% - 0.7rem);
+  }
+
+  .card-listing--3-col .card:nth-child(3n + 1),
+  .card-listing--3-col .card:nth-child(3n + 2) {
+    margin-right: 1.05rem;
+  }
+
+  .card-listing--4-col .card:nth-child(4n + 1),
+  .card-listing--4-col .card:nth-child(4n + 2),
+  .card-listing--4-col .card:nth-child(4n + 3) {
+    margin-right: 0.933rem;
+  }
+}
+
 .card-listing__heading {
   text-align: center;
   width: 100%;

--- a/src/css/elements/_cards.css
+++ b/src/css/elements/_cards.css
@@ -1,7 +1,6 @@
 .card-listing {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   padding: 1.4rem 0;
 }
 
@@ -13,28 +12,42 @@
 
 /* Blog listing - card */
 
-@media (max-width: 767px) {
-  .card-listing--2-col .card {
+@media (min-width: 1000px) {
+  .card-listing--2-cols {
+    justify-content: space-between;
+  }
+
+  .card-listing--2-cols .card {
     width: calc(50% - 0.7rem);
   }
 
-  .card-listing--3-col .card {
+  .card-listing--3-cols .card {
     width: calc(33.3% - 0.7rem);
   }
 
-  .card-listing--4-col .card {
+  .card-listing--4-cols .card {
     width: calc(25% - 0.7rem);
   }
 
-  .card-listing--3-col .card:nth-child(3n + 1),
-  .card-listing--3-col .card:nth-child(3n + 2) {
+  .card-listing--3-cols .card:nth-child(3n + 1),
+  .card-listing--3-cols .card:nth-child(3n + 2) {
     margin-right: 1.05rem;
   }
 
-  .card-listing--4-col .card:nth-child(4n + 1),
-  .card-listing--4-col .card:nth-child(4n + 2),
-  .card-listing--4-col .card:nth-child(4n + 3) {
+  .card-listing--4-cols .card:nth-child(4n + 1),
+  .card-listing--4-cols .card:nth-child(4n + 2),
+  .card-listing--4-cols .card:nth-child(4n + 3) {
     margin-right: 0.933rem;
+  }
+}
+
+@media (min-width: 767px) and (max-width: 1000px) {
+  .card-listing {
+    justify-content: space-between;
+  }
+
+  .card-listing .card {
+    width: calc(50% - 0.7rem);
   }
 }
 

--- a/src/css/elements/_cards.css
+++ b/src/css/elements/_cards.css
@@ -45,6 +45,8 @@
 
 .card {
   border: 2px solid #494A52;
+  display: flex;
+  flex-direction: column;
   margin-bottom: 1.4rem;
   padding: 1.4rem;
   width: 100%;
@@ -63,4 +65,8 @@
 .card__item {
   display: block;
   margin-bottom: 0.7rem;
+}
+
+.card__button-wrapper {
+  margin-top: auto;
 }

--- a/src/modules/application-listing.module/fields.json
+++ b/src/modules/application-listing.module/fields.json
@@ -302,22 +302,22 @@
             "type": "group",
             "children": [
               {
-                "label": "Space between cards",
-                "name": "space_between_cards",
-                "type": "number",
-                "display": "slider",
-                "max": 50,
-                "min": 0,
-                "step": 5,
-                "suffix": "px"
-              },
-              {
                 "label": "Card content",
                 "name": "card_content",
                 "type": "spacing",
                 "visibility": {
                   "hidden_subfields": {
                     "margin": true
+                  }
+                }
+              },
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing",
+                "visibility": {
+                  "hidden_subfields": {
+                    "padding": true
                   }
                 }
               }

--- a/src/modules/application-listing.module/module.html
+++ b/src/modules/application-listing.module/module.html
@@ -158,7 +158,7 @@
 
   {# Application listing #}
 
-  <section class="card-listing">
+  <section class="card-listing card-listing--{{ module.columns }}-cols">
 
     {# Heading #}
 

--- a/src/modules/application-listing.module/module.html
+++ b/src/modules/application-listing.module/module.html
@@ -22,22 +22,9 @@
       {% if module.styles.cards.corner.radius %}
         border-radius: {{ module.styles.cards.corner.radius ~ 'px' }};
       {% endif %}
+      {{ module.styles.cards.spacing.spacing.css }}
       {{ module.styles.cards.spacing.card_content.css }}
     }
-
-    {% if module.styles.cards.spacing.space_between_cards %}
-      @media (min-width: 767px) {
-        .card {
-          width: calc({{ 100 / module.columns }}% - {{ module.styles.cards.spacing.space_between_cards ~ 'px' }});
-        }
-      }
-    {% else %}
-      @media (min-width: 767px) {
-        .card {
-          width: calc({{ 100 / module.columns }}% - 0.7rem);
-        }
-      }
-    {% endif %}
 
     {# Card content #}
 
@@ -46,7 +33,7 @@
     }
 
     .card__subheading {
-     {{ module.styles.cards.subheading.font.css }}
+      {{ module.styles.cards.subheading.font.css }}
     }
 
     .card__item-label {
@@ -59,9 +46,9 @@
 
     {# Button wrapper #}
 
-    {% if module.styles.alignment.alignment %}
+    {% if module.styles.cards.button.alignment.alignment %}
       .button-wrapper {
-        text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+        text-align: {{ module.styles.cards.button.alignment.alignment.horizontal_align }};
       }
     {% endif %}
 

--- a/src/modules/featured-roles.module/fields.json
+++ b/src/modules/featured-roles.module/fields.json
@@ -10,7 +10,7 @@
     "name": "roles_to_show",
     "type": "number",
     "display": "text",
-    "max": 3,
+    "max": 4,
     "min": 2,
     "required": true,
     "step": 1,

--- a/src/modules/featured-roles.module/fields.json
+++ b/src/modules/featured-roles.module/fields.json
@@ -244,22 +244,22 @@
             "type": "group",
             "children": [
               {
-                "label": "Space between cards",
-                "name": "space_between_cards",
-                "type": "number",
-                "display": "slider",
-                "max": 50,
-                "min": 0,
-                "step": 5,
-                "suffix": "px"
-              },
-              {
                 "label": "Card content",
                 "name": "card_content",
                 "type": "spacing",
                 "visibility": {
                   "hidden_subfields": {
                     "margin": true
+                  }
+                }
+              },
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing",
+                "visibility": {
+                  "hidden_subfields": {
+                    "padding": true
                   }
                 }
               }

--- a/src/modules/featured-roles.module/module.html
+++ b/src/modules/featured-roles.module/module.html
@@ -22,22 +22,9 @@
     {% if module.styles.cards.corner.radius %}
       border-radius: {{ module.styles.cards.corner.radius ~ 'px' }};
     {% endif %}
+    {{ module.styles.cards.spacing.spacing.css }}
     {{ module.styles.cards.spacing.card_content.css }}
   }
-
-  {% if module.styles.cards.spacing.space_between_cards %}
-    @media (min-width: 767px) {
-      .card {
-        width: calc({{ 100 / module.roles_to_show }}% - {{ module.styles.cards.spacing.space_between_cards ~ 'px' }});
-      }
-    }
-  {% else %}
-    @media (min-width: 767px) {
-      .card {
-        width: calc({{ 100 / module.roles_to_show }}% - 0.7rem);
-      }
-    }
-  {% endif %}
 
   {# Card content #}
 
@@ -55,9 +42,9 @@
 
   {# Button wrapper #}
 
-  {% if module.styles.alignment.alignment %}
+  {% if module.styles.cards.button.alignment.alignment %}
     .button-wrapper {
-      text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+      text-align: {{ module.styles.cards.button.alignment.alignment.horizontal_align }};
     }
   {% endif %}
 

--- a/src/modules/featured-roles.module/module.html
+++ b/src/modules/featured-roles.module/module.html
@@ -110,7 +110,9 @@
         <h3 class="card__heading">{{ role.title }}</h3>
         <h4 class="card__subheading">{{ company.name }}</h4>
         <p class="card__description">{{ truncate(role.description|striptags, module.card.length_of_description || 255, false, '...') }}</p>
-        <a class="card__button button" href="{{ roleDetailLink }}">{{ module.card.button_text }}</a>
+        <div class="card__button-wrapper button-wrapper">
+          <a class="card__button button" href="{{ roleDetailLink }}">{{ module.card.button_text }}</a>
+        </div>
       </div>
     {% endfor %}
   </section>

--- a/src/modules/featured-roles.module/module.html
+++ b/src/modules/featured-roles.module/module.html
@@ -100,7 +100,7 @@
 {# Featured roles #}
 
 {% if roles|length > 0 %}
-  <section class="card-listing">
+  <section class="card-listing card-listing--{{ module.roles_to_show }}-cols">
     <h2 class="card-listing__heading">{{ module.heading }}</h2>
     {% for role in roles %}
       {% set company = dataQueryData.company_collection.items[0] %}

--- a/src/modules/role-listing.module/fields.json
+++ b/src/modules/role-listing.module/fields.json
@@ -4,7 +4,7 @@
     "name": "cards_per_row",
     "type": "number",
     "display": "text",
-    "max": 5,
+    "max": 4,
     "min": 2,
     "required": true,
     "step": 1,

--- a/src/modules/role-listing.module/fields.json
+++ b/src/modules/role-listing.module/fields.json
@@ -258,22 +258,22 @@
             "type": "group",
             "children": [
               {
-                "label": "Space between cards",
-                "name": "space_between_cards",
-                "type": "number",
-                "display": "slider",
-                "max": 50,
-                "min": 0,
-                "step": 5,
-                "suffix": "px"
-              },
-              {
                 "label": "Card content",
                 "name": "card_content",
                 "type": "spacing",
                 "visibility": {
                   "hidden_subfields": {
                     "margin": true
+                  }
+                }
+              },
+              {
+                "label": "Spacing",
+                "name": "spacing",
+                "type": "spacing",
+                "visibility": {
+                  "hidden_subfields": {
+                    "padding": true
                   }
                 }
               }

--- a/src/modules/role-listing.module/module.html
+++ b/src/modules/role-listing.module/module.html
@@ -225,7 +225,7 @@
 
 {# Role listing #}
 
-<div class="card-listing content-wrapper">
+<div class="card-listing content-wrapper card-listing--{{ module.cards_per_row }}-cols">
 
   {% if roles|length == 0 %}
     <h2>No results found</h2>

--- a/src/modules/role-listing.module/module.html
+++ b/src/modules/role-listing.module/module.html
@@ -25,22 +25,9 @@
       {% if module.styles.cards.corner.radius %}
         border-radius: {{ module.styles.cards.corner.radius ~ 'px' }};
       {% endif %}
+      {{ module.styles.cards.spacing.spacing.css }}
       {{ module.styles.cards.spacing.card_content.css }}
     }
-
-    {% if module.styles.cards.spacing.space_between_cards %}
-      @media (min-width: 767px) {
-        .card {
-          width: calc({{ 100 / module.cards_per_row }}% - {{ module.styles.cards.spacing.space_between_cards ~ 'px' }});
-        }
-      }
-    {% else %}
-      @media (min-width: 767px) {
-        .card {
-          width: calc({{ 100 / module.cards_per_row }}% - 0.7rem);
-        }
-      }
-    {% endif %}
 
     {# Card content #}
 
@@ -58,9 +45,9 @@
 
     {# Button wrapper #}
 
-    {% if module.styles.alignment.alignment %}
+    {% if module.styles.cards.button.alignment.alignment %}
       .button-wrapper {
-        text-align: {{ module.styles.alignment.alignment.horizontal_align }};
+        text-align: {{ module.styles.cards.button.alignment.alignment.horizontal_align }};
       }
     {% endif %}
 

--- a/src/modules/role-listing.module/module.html
+++ b/src/modules/role-listing.module/module.html
@@ -246,7 +246,9 @@
       <h2 class="card__heading">{{ role.title }}</h2>
       <h3 class="card__subheading">{{ company.name }}</h3>
       <p class="card__description">{{ truncate(role.description|striptags, module.card.length_of_description, false, '...') }}</p>
-      <a class="card__button button" href="{{ roleDetailLink }}">Apply</a>
+      <div class="card__button-wrapper button-wrapper">
+        <a class="card__button button" href="{{ roleDetailLink }}">Apply</a>
+      </div>
     </section>
   {% endfor %}
 


### PR DESCRIPTION
Fixing card alignment if there are more than 2 cards per row and one of the rows doesn't have the full amount of cards. The issue was we were leveraging `justify-content: space-between;` which was great for two card rows but doesn't work out well in a 3/4 column row if there are not 3/4 cards (note this is specifically if we want the outer cards to line up along the edge of the container). The solution was to avoid justify-content and use nth-child to handle the spacing depending on how many columns there are. I also added a couple of minor enhancements here (moved button to always align towards bottom of card so this was more aesthetically pleasing and had 3-4 column layouts shift down to two columns for smaller laptop/tablet before going down to one column on mobile). Adding a few screenshots below:
![Screen Shot 2021-11-08 at 3 51 24 PM](https://user-images.githubusercontent.com/22665237/140816560-f2f20a13-7478-4d5e-8104-2363d21b37b5.png)

![Screen Shot 2021-11-08 at 3 52 03 PM](https://user-images.githubusercontent.com/22665237/140816563-9103a238-603d-44f6-9a81-f9ca6395dd9c.png)

