### PR TITLE
Removing CLI as dev dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@hubspot/cli": "^3.0.9",
     "autoprefixer": "^9.0.0",
     "eslint": "^7.9.0",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
Removing CLI dev dependency in `package.json` because it isn't needed and it is recommended to download the CLI on a global level to make maintenance/upgrades easier (see thread in boilerplate for similar update: https://github.com/HubSpot/cms-theme-boilerplate/pull/390). 