### PR TITLE
Make description an html field type

### DIFF
--- a/schemas/role.json
+++ b/schemas/role.json
@@ -45,7 +45,7 @@
       "name": "description",
       "label": "Description",
       "type": "string",
-      "fieldType": "textarea",
+      "fieldType": "html",
       "description": ""
     },
     {


### PR DESCRIPTION
@williamspiro it appears the CLI works for creating schemas with rich text properties now, so we should be good to merge this.